### PR TITLE
Add MySQL and perf controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ mvn install
 mvn spring-boot:run
 ```
 http://localhost:8080/query?sql=select%20%22state_province%22,%20count(*)%20as%20c%20from%20%22foodmart%22%20where%20%22timestamp%22%20%3E=%20%271900-01-011T1:00:00.000Z%27%20and%20%22timestamp%22%20%3C%20%272019-01-01T12:00:00.000Z%27%20and%20%22product_name%22%20=%20%27High%20Top%20Dried%20Mushrooms%27%20group%20by%20%22state_province%22
+
+http://localhost:8080/query?sql=select%20count(*)%20from%20%22foodmart%22
+
+http://localhost:8080/mysql?sql=select%20count(*)%20from%20%22foodmart%22
+

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ http://localhost:8080/query?sql=select%20count(*)%20from%20%22foodmart%22
 
 http://localhost:8080/mysql?sql=select%20count(*)%20from%20%22foodmart%22
 
+http://localhost:8080/perf?sql=select%20count(*)%20from%20%22foodmart%22
+

--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.36</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependency>
     </dependencies>
 
     <properties>
     <java.version>1.8</java.version>
     </properties>
-
 
     <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.huawei.cloudsop.us</groupId>
     <artifactId>query-engine</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.19.0-SNAPSHOT</version>
+            <version>1.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-druid</artifactId>
-            <version>1.19.0-SNAPSHOT</version>
+            <version>1.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/huawei/cloudsop/us/queryengine/CalciteQueryManager.java
+++ b/src/main/java/com/huawei/cloudsop/us/queryengine/CalciteQueryManager.java
@@ -16,6 +16,9 @@ public class CalciteQueryManager {
     public static final URL FOODMART =
             CalciteQueryManager.class.getResource("/druid-foodmart-model.json");
 
+    public static final URL MYSQL_FOODMART =
+        CalciteQueryManager.class.getResource("/mysql-foodmart-model.json");
+
     /** URL of the "druid-wiki" model
      * and the "wikiticker" data set. */
     public static final URL WIKI =

--- a/src/main/java/com/huawei/cloudsop/us/queryengine/MySqlController.java
+++ b/src/main/java/com/huawei/cloudsop/us/queryengine/MySqlController.java
@@ -1,0 +1,23 @@
+package com.huawei.cloudsop.us.queryengine;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MySqlController {
+
+    private final AtomicLong counter = new AtomicLong();
+
+    private final CalciteQueryManager manager = new CalciteQueryManager();
+
+    @RequestMapping("/mysql")
+    public QueryResult mysql(
+            @RequestParam(value="model", defaultValue="") String model,
+            @RequestParam(value="sql", defaultValue="") String sql) {
+      return new QueryResult(counter.incrementAndGet(),
+          manager.query(CalciteQueryManager.MYSQL_FOODMART, sql));
+    }
+}

--- a/src/main/java/com/huawei/cloudsop/us/queryengine/PerfController.java
+++ b/src/main/java/com/huawei/cloudsop/us/queryengine/PerfController.java
@@ -1,0 +1,91 @@
+package com.huawei.cloudsop.us.queryengine;
+
+import org.apache.calcite.avatica.metrics.Timer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for performance testing
+ */
+@RestController
+public class PerfController {
+
+    private final AtomicLong counter = new AtomicLong();
+
+    private final CalciteQueryManager manager = new CalciteQueryManager();
+
+    private final Map<String, PerfTimer> timers = new LinkedHashMap<>();
+
+    private Timer getTimer(String name){
+        return this.timers.computeIfAbsent(name, PerfTimer::new);
+    }
+
+    private Map<String, Object> getMetrics() {
+        Map<String, Object> toReturn = new LinkedHashMap<>();
+        this.timers.forEach((k, v) -> toReturn.put(k, v.getDuration()));
+        return toReturn;
+    }
+
+    @RequestMapping("/perf")
+    public QueryResult perf(
+        @RequestParam(value = "sql", defaultValue = "") String sql) {
+
+        // Query MySQL and measure query execution latency
+        try (Timer.Context ignored = getTimer("MySQL").start()) {
+            MySqlController c = new MySqlController();
+            c.mysql("", sql);
+        }
+
+        // Query Druid and measure query execution latency
+        try (Timer.Context ignored = getTimer("Druid").start()) {
+            QueryController c = new QueryController();
+            c.query("", sql);
+        }
+
+        // Generate perf metrics
+        ObjectMapper mapper = new ObjectMapper();
+        String perfMetricsJson = "{}";
+        try {
+            perfMetricsJson = mapper.writeValueAsString(getMetrics());
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            perfMetricsJson = "{\"" + e.getMessage() + "\"}";
+        }
+        return new QueryResult(counter.incrementAndGet(), perfMetricsJson);
+    }
+
+    private static class PerfTimer implements Timer {
+        final String name;
+        private long from;
+        private long to;
+
+        PerfTimer(String name) {
+            this.name = name;
+        }
+
+        @Override public Context start() {
+            final AtomicBoolean closed = new AtomicBoolean();
+            this.from = System.currentTimeMillis();
+            return () -> {
+                if (closed.compareAndSet(false, true)){
+                    this.to = System.currentTimeMillis();
+                }
+            };
+        }
+
+        public long getDuration() {
+            return this.to - this.from;
+        }
+    }
+
+}

--- a/src/main/resources/mysql-foodmart-model.json
+++ b/src/main/resources/mysql-foodmart-model.json
@@ -1,0 +1,17 @@
+{
+  version: '1.0',
+  defaultSchema: 'FOODMART',
+  schemas: [
+    {
+      name: 'FOODMART',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://mydbinstance.cvjh6uodgi1s.us-west-2.rds.amazonaws.com/foodmart',
+        jdbcUser: 'root',
+        jdbcPassword: 'password'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change allows you to run a perf query using URL like this:

http://localhost:8080/perf?sql=select%20count(*)%20from%20%22foodmart%22

Which shows perf metrics like this:

{"id":7,"content":"{\"MySQL\":192,\"Druid\":64}"}

The perf metrics are time in milliseconds which took to query each database.