### PR TITLE
Use EC2 Druid instance for MySQL queries

### DIFF
--- a/src/main/resources/mysql-foodmart-model.json
+++ b/src/main/resources/mysql-foodmart-model.json
@@ -8,9 +8,9 @@
       factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
       operand: {
         jdbcDriver: 'com.mysql.jdbc.Driver',
-        jdbcUrl: 'jdbc:mysql://mydbinstance.cvjh6uodgi1s.us-west-2.rds.amazonaws.com/foodmart',
+        jdbcUrl: 'jdbc:mysql://ec2-54-202-170-44.us-west-2.compute.amazonaws.com/foodmart',
         jdbcUser: 'root',
-        jdbcPassword: 'password'
+        jdbcPassword: 'pass'
       }
     }
   ]


### PR DESCRIPTION
I've fixed EC2 MySQL connection issues, so now we can use it instead of RDS