### PR TITLE
add demoable query

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ http://localhost:8080/join?sql=select%22t1%22.*,%22t2%22.*from%22foodmart%22.%22
 
 http://localhost:8080/join?sql=SELECT%20%22foodmart%22.%22foodmart%22.%22product_name%22%20FROM%20%22foodmart%22.%22foodmart%22%20INNER%20JOIN%20%22db_example%22.%22persons%22%20ON%20%22db_example%22.%22persons%22.%22PersonID%22=%22foodmart%22.%22foodmart%22.%22customer_id%22
 
-http://localhost:8080/druidmysqljoin?sql= select"t1".*from"mysql"."foodmart"as"t1"join"druid"."foodmart"as"t2"on"t1"."postal_code"="t2"."postal_code"and"t2"."timestamp" >= '1900-01-01T00:00:00.000Z' and "t2"."timestamp" < '1997-01-01T12:00:00.000Z'
+http://localhost:8080/druidmysqljoin?sql=select%22t1%22.*from%22mysql%22.%22foodmart%22as%22t1%22join%22druid%22.%22foodmart%22as%22t2%22on%22t1%22.%22postal_code%22=%22t2%22.%22postal_code%22and%22t2%22.%22timestamp%22%3E=%271900-01-01T00:00:00.000Z%27and%22t2%22.%22timestamp%22%3C%271997-01-01T12:00:00.000Z%27and%22t1%22.%22postal_code%22=12422

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.9.8</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/resources/druid-foodmart-model-timestamp.json
+++ b/src/main/resources/druid-foodmart-model-timestamp.json
@@ -23,8 +23,8 @@
       "name": "foodmart",
       "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
       "operand": {
-        "url": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8082",
-        "coordinatorUrl": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8081"
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
       },
       "tables": [
         {

--- a/src/main/resources/druid-foodmart-model.json
+++ b/src/main/resources/druid-foodmart-model.json
@@ -23,8 +23,8 @@
       "name": "foodmart",
       "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
       "operand": {
-        "url": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8082",
-        "coordinatorUrl": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8081"
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
       },
       "tables": [
         {

--- a/src/main/resources/druid-mysql-foodmart-model.json
+++ b/src/main/resources/druid-mysql-foodmart-model.json
@@ -7,8 +7,8 @@
       "name": "druid",
       "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
       "operand": {
-        "url": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8082",
-        "coordinatorUrl": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8081"
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
       },
       "tables": [
         {
@@ -139,7 +139,7 @@
       factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
       operand: {
         jdbcDriver: 'com.mysql.jdbc.Driver',
-        jdbcUrl: 'jdbc:mysql://ec2-54-202-170-44.us-west-2.compute.amazonaws.com/foodmart',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart',
         jdbcUser: 'root',
         jdbcPassword: 'pass'
       }

--- a/src/main/resources/druid-mysql-model.json
+++ b/src/main/resources/druid-mysql-model.json
@@ -8,7 +8,7 @@
       factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
       operand: {
         jdbcDriver: 'com.mysql.jdbc.Driver',
-        jdbcUrl: 'jdbc:mysql://ec2-54-202-170-44.us-west-2.compute.amazonaws.com/db_example',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/db_example',
         jdbcUser: 'root',
         jdbcPassword: 'pass'
       }
@@ -18,8 +18,8 @@
       "name": "foodmart",
       "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
       "operand": {
-        "url": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8082",
-        "coordinatorUrl": "http://ec2-54-202-170-44.us-west-2.compute.amazonaws.com:8081"
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
       },
       "tables": [
         {

--- a/src/main/resources/mysql-foodmart-model.json
+++ b/src/main/resources/mysql-foodmart-model.json
@@ -8,7 +8,7 @@
       factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
       operand: {
         jdbcDriver: 'com.mysql.jdbc.Driver',
-        jdbcUrl: 'jdbc:mysql://ec2-54-202-170-44.us-west-2.compute.amazonaws.com/foodmart',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart',
         jdbcUser: 'root',
         jdbcPassword: 'pass'
       }

--- a/src/main/resources/mysql-persons-model.json
+++ b/src/main/resources/mysql-persons-model.json
@@ -8,7 +8,7 @@
       factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
       operand: {
         jdbcDriver: 'com.mysql.jdbc.Driver',
-        jdbcUrl: 'jdbc:mysql://ec2-54-202-170-44.us-west-2.compute.amazonaws.com/db_example',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/db_example',
         jdbcUser: 'root',
         jdbcPassword: 'pass'
       }

--- a/src/test/java/com/huawei/cloudsop/us/queryengine/ControllerTest.java
+++ b/src/test/java/com/huawei/cloudsop/us/queryengine/ControllerTest.java
@@ -1,0 +1,14 @@
+package com.huawei.cloudsop.us.queryengine;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ControllerTest {
+
+    @Test public void testDruidMySqlJoinController() {
+            DruidMySqlJoinController controller = new DruidMySqlJoinController();
+        QueryResult result = controller.druidmysqljoin("","select\"t1\".*from\"mysql\".\"foodmart\"as\"t1\"join\"druid\".\"foodmart\"as\"t2\"on\"t1\".\"postal_code\"=\"t2\".\"postal_code\"and\"t2\".\"timestamp\">='1900-01-01T00:00:00.000Z'and\"t2\".\"timestamp\"<'1997-01-01T12:00:00.000Z'and\"t1\".\"postal_code\"=12422");
+        assertEquals(31902, result.getContent().length());
+    }
+}

--- a/src/test/resources/druid-foodmart-model-timestamp.json
+++ b/src/test/resources/druid-foodmart-model-timestamp.json
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "foodmart",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "foodmart",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
+      },
+      "tables": [
+        {
+          "name": "foodmart",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": {
+              "name": "timestamp",
+              "type": "timestamp"
+            },
+            "dimensions": [
+              "product_id",
+              "brand_name",
+              "product_name",
+              "SKU",
+              "SRP",
+              "gross_weight",
+              "net_weight",
+              "recyclable_package",
+              "low_fat",
+              "units_per_case",
+              "cases_per_pallet",
+              "shelf_width",
+              "shelf_height",
+              "shelf_depth",
+              "product_class_id",
+              "product_subcategory",
+              "product_category",
+              "product_department",
+              "product_family",
+              "customer_id",
+              "account_num",
+              "lname",
+              "fname",
+              "mi",
+              "address1",
+              "address2",
+              "address3",
+              "address4",
+              "city",
+              "state_province",
+              "postal_code",
+              "country",
+              "customer_region_id",
+              "phone1",
+              "phone2",
+              "birthdate",
+              "marital_status",
+              "yearly_income",
+              "gender",
+              "total_children",
+              "num_children_at_home",
+              "education",
+              "date_accnt_opened",
+              "member_card",
+              "occupation",
+              "houseowner",
+              "num_cars_owned",
+              "fullname",
+              "promotion_id",
+              "promotion_district_id",
+              "promotion_name",
+              "media_type",
+              "cost",
+              "start_date",
+              "end_date",
+              "store_id",
+              "store_type",
+              "region_id",
+              "store_name",
+              "store_number",
+              "store_street_address",
+              "store_city",
+              "store_state",
+              "store_postal_code",
+              "store_country",
+              "store_manager",
+              "store_phone",
+              "store_fax",
+              "first_opened_date",
+              "last_remodel_date",
+              "store_sqft",
+              "grocery_sqft",
+              "frozen_sqft",
+              "meat_sqft",
+              "coffee_bar",
+              "video_store",
+              "salad_bar",
+              "prepared_food",
+              "florist",
+              "time_id",
+              "the_day",
+              "the_month",
+              "the_year",
+              "day_of_month",
+              "week_of_year",
+              "month_of_year",
+              "quarter",
+              "fiscal_period"
+            ],
+            "metrics": [
+              "unit_sales",
+              {
+                "name": "store_sales",
+                "type": "double"
+              },
+              {
+                "name": "store_cost",
+                "type": "double"
+              },
+              {
+                "name" : "customer_id_ts",
+                "type" : "thetaSketch",
+                "fieldName" : "customer_id"
+              }
+            ],
+            "complexMetrics" : [
+              "customer_id"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/druid-foodmart-model.json
+++ b/src/test/resources/druid-foodmart-model.json
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "foodmart",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "foodmart",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
+      },
+      "tables": [
+        {
+          "name": "foodmart",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": {
+              "name": "timestamp",
+              "type": "timestamp with local time zone"
+            },
+            "dimensions": [
+              "product_id",
+              "brand_name",
+              "product_name",
+              "SKU",
+              "SRP",
+              "gross_weight",
+              "net_weight",
+              "recyclable_package",
+              "low_fat",
+              "units_per_case",
+              "cases_per_pallet",
+              "shelf_width",
+              "shelf_height",
+              "shelf_depth",
+              "product_class_id",
+              "product_subcategory",
+              "product_category",
+              "product_department",
+              "product_family",
+              "customer_id",
+              "account_num",
+              "lname",
+              "fname",
+              "mi",
+              "address1",
+              "address2",
+              "address3",
+              "address4",
+              "city",
+              "state_province",
+              "postal_code",
+              "country",
+              "customer_region_id",
+              "phone1",
+              "phone2",
+              "birthdate",
+              "marital_status",
+              "yearly_income",
+              "gender",
+              "total_children",
+              "num_children_at_home",
+              "education",
+              "date_accnt_opened",
+              "member_card",
+              "occupation",
+              "houseowner",
+              "num_cars_owned",
+              "fullname",
+              "promotion_id",
+              "promotion_district_id",
+              "promotion_name",
+              "media_type",
+              "cost",
+              "start_date",
+              "end_date",
+              "store_id",
+              "store_type",
+              "region_id",
+              "store_name",
+              "store_number",
+              "store_street_address",
+              "store_city",
+              "store_state",
+              "store_postal_code",
+              "store_country",
+              "store_manager",
+              "store_phone",
+              "store_fax",
+              "first_opened_date",
+              "last_remodel_date",
+              "store_sqft",
+              "grocery_sqft",
+              "frozen_sqft",
+              "meat_sqft",
+              "coffee_bar",
+              "video_store",
+              "salad_bar",
+              "prepared_food",
+              "florist",
+              "time_id",
+              "the_day",
+              "the_month",
+              "the_year",
+              "day_of_month",
+              "week_of_year",
+              "month_of_year",
+              "quarter",
+              "fiscal_period"
+            ],
+            "metrics": [
+              "unit_sales",
+              {
+                "name": "store_sales",
+                "type": "double"
+              },
+              {
+                "name": "store_cost",
+                "type": "double"
+              },
+              {
+                "name" : "customer_id_ts",
+                "type" : "thetaSketch",
+                "fieldName" : "customer_id"
+              }
+            ],
+            "complexMetrics" : [
+              "customer_id"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/druid-mysql-foodmart-model.json
+++ b/src/test/resources/druid-mysql-foodmart-model.json
@@ -1,0 +1,148 @@
+{
+  version: '1.0',
+  //defaultSchema: 'persons',
+  schemas: [
+    {
+      "type": "custom",
+      "name": "druid",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
+      },
+      "tables": [
+        {
+          "name": "foodmart",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": {
+              "name": "timestamp",
+              "type": "timestamp with local time zone"
+            },
+            "dimensions": [
+              "product_id",
+              "brand_name",
+              "product_name",
+              "SKU",
+              "SRP",
+              "gross_weight",
+              "net_weight",
+              "recyclable_package",
+              "low_fat",
+              "units_per_case",
+              "cases_per_pallet",
+              "shelf_width",
+              "shelf_height",
+              "shelf_depth",
+              "product_class_id",
+              "product_subcategory",
+              "product_category",
+              "product_department",
+              "product_family",
+              "customer_id",
+              "account_num",
+              "lname",
+              "fname",
+              "mi",
+              "address1",
+              "address2",
+              "address3",
+              "address4",
+              "city",
+              "state_province",
+              "postal_code",
+              "country",
+              "customer_region_id",
+              "phone1",
+              "phone2",
+              "birthdate",
+              "marital_status",
+              "yearly_income",
+              "gender",
+              "total_children",
+              "num_children_at_home",
+              "education",
+              "date_accnt_opened",
+              "member_card",
+              "occupation",
+              "houseowner",
+              "num_cars_owned",
+              "fullname",
+              "promotion_id",
+              "promotion_district_id",
+              "promotion_name",
+              "media_type",
+              "cost",
+              "start_date",
+              "end_date",
+              "store_id",
+              "store_type",
+              "region_id",
+              "store_name",
+              "store_number",
+              "store_street_address",
+              "store_city",
+              "store_state",
+              "store_postal_code",
+              "store_country",
+              "store_manager",
+              "store_phone",
+              "store_fax",
+              "first_opened_date",
+              "last_remodel_date",
+              "store_sqft",
+              "grocery_sqft",
+              "frozen_sqft",
+              "meat_sqft",
+              "coffee_bar",
+              "video_store",
+              "salad_bar",
+              "prepared_food",
+              "florist",
+              "time_id",
+              "the_day",
+              "the_month",
+              "the_year",
+              "day_of_month",
+              "week_of_year",
+              "month_of_year",
+              "quarter",
+              "fiscal_period"
+            ],
+            "metrics": [
+              "unit_sales",
+              {
+                "name": "store_sales",
+                "type": "double"
+              },
+              {
+                "name": "store_cost",
+                "type": "double"
+              },
+              {
+                "name" : "customer_id_ts",
+                "type" : "thetaSketch",
+                "fieldName" : "customer_id"
+              }
+            ],
+            "complexMetrics" : [
+              "customer_id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      name: 'mysql',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    }
+  ]
+}

--- a/src/test/resources/druid-mysql-model.json
+++ b/src/test/resources/druid-mysql-model.json
@@ -1,0 +1,148 @@
+{
+  version: '1.0',
+  //defaultSchema: 'FOODMART',
+  schemas: [
+    {
+      name: 'db_example',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/db_example',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    },
+    {
+      "type": "custom",
+      "name": "foodmart",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8082",
+        "coordinatorUrl": "http://ec2-54-201-169-42.us-west-2.compute.amazonaws.com:8081"
+      },
+      "tables": [
+        {
+          "name": "foodmart",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": {
+              "name": "timestamp",
+              "type": "timestamp with local time zone"
+            },
+            "dimensions": [
+              "product_id",
+              "brand_name",
+              "product_name",
+              "SKU",
+              "SRP",
+              "gross_weight",
+              "net_weight",
+              "recyclable_package",
+              "low_fat",
+              "units_per_case",
+              "cases_per_pallet",
+              "shelf_width",
+              "shelf_height",
+              "shelf_depth",
+              "product_class_id",
+              "product_subcategory",
+              "product_category",
+              "product_department",
+              "product_family",
+              "customer_id",
+              "account_num",
+              "lname",
+              "fname",
+              "mi",
+              "address1",
+              "address2",
+              "address3",
+              "address4",
+              "city",
+              "state_province",
+              "postal_code",
+              "country",
+              "customer_region_id",
+              "phone1",
+              "phone2",
+              "birthdate",
+              "marital_status",
+              "yearly_income",
+              "gender",
+              "total_children",
+              "num_children_at_home",
+              "education",
+              "date_accnt_opened",
+              "member_card",
+              "occupation",
+              "houseowner",
+              "num_cars_owned",
+              "fullname",
+              "promotion_id",
+              "promotion_district_id",
+              "promotion_name",
+              "media_type",
+              "cost",
+              "start_date",
+              "end_date",
+              "store_id",
+              "store_type",
+              "region_id",
+              "store_name",
+              "store_number",
+              "store_street_address",
+              "store_city",
+              "store_state",
+              "store_postal_code",
+              "store_country",
+              "store_manager",
+              "store_phone",
+              "store_fax",
+              "first_opened_date",
+              "last_remodel_date",
+              "store_sqft",
+              "grocery_sqft",
+              "frozen_sqft",
+              "meat_sqft",
+              "coffee_bar",
+              "video_store",
+              "salad_bar",
+              "prepared_food",
+              "florist",
+              "time_id",
+              "the_day",
+              "the_month",
+              "the_year",
+              "day_of_month",
+              "week_of_year",
+              "month_of_year",
+              "quarter",
+              "fiscal_period"
+            ],
+            "metrics": [
+              "unit_sales",
+              {
+                "name": "store_sales",
+                "type": "double"
+              },
+              {
+                "name": "store_cost",
+                "type": "double"
+              },
+              {
+                "name" : "customer_id_ts",
+                "type" : "thetaSketch",
+                "fieldName" : "customer_id"
+              }
+            ],
+            "complexMetrics" : [
+              "customer_id"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/druid-wiki-model.json
+++ b/src/test/resources/druid-wiki-model.json
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "wiki",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "wiki",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://54.245.26.58:8082",
+        "coordinatorUrl": "http://54.245.26.58:8081"
+      },
+      "tables": [
+        {
+          "name": "wiki",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "dataSource": "wikiticker",
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": "time",
+            "dimensions": [
+              "channel",
+              "cityName",
+              "comment",
+              "countryIsoCode",
+              "countryName",
+              "isAnonymous",
+              "isMinor",
+              "isNew",
+              "isRobot",
+              "isUnpatrolled",
+              "metroCode",
+              "namespace",
+              "page",
+              "regionIsoCode",
+              "regionName"
+            ],
+            "metrics": [
+              {
+                "name" : "count",
+                "type" : "count"
+              },
+              {
+                "name" : "added",
+                "type" : "longSum",
+                "fieldName" : "added"
+              },
+              {
+                "name" : "deleted",
+                "type" : "longSum",
+                "fieldName" : "deleted"
+              },
+              {
+                "name" : "delta",
+                "type" : "longSum",
+                "fieldName" : "delta"
+              },
+              {
+                "name" : "user_unique",
+                "type" : "hyperUnique",
+                "fieldName" : "user_id"
+              }
+            ],
+            "complexMetrics" : [
+              "user_id"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/druid-wiki-no-columns-model.json
+++ b/src/test/resources/druid-wiki-no-columns-model.json
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Druid model that has one table defined, and table has no columns, so adapter
+ * needs to discover columns.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "wiki",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "wiki",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://54.245.26.58:8082",
+        "coordinatorUrl": "http://54.245.26.58:8081"
+      },
+      "tables": [
+        {
+          "name": "wiki",
+          "factory": "org.apache.calcite.adapter.druid.DruidTableFactory",
+          "operand": {
+            "dataSource": "wikiticker",
+            "interval": "1900-01-09T00:00:00.000Z/2992-01-10T00:00:00.000Z",
+            "timestampColumn": "time"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/druid-wiki-no-tables-model.json
+++ b/src/test/resources/druid-wiki-no-tables-model.json
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Druid model where there are no table definitions.
+ */
+{
+  "version": "1.0",
+  "defaultSchema": "wiki",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "wiki",
+      "factory": "org.apache.calcite.adapter.druid.DruidSchemaFactory",
+      "operand": {
+        "url": "http://54.245.26.58:8082",
+        "coordinatorUrl": "http://54.245.26.58:8081"
+      }
+    }
+  ]
+}

--- a/src/test/resources/foodmart-schema.spec
+++ b/src/test/resources/foodmart-schema.spec
@@ -1,0 +1,73 @@
+[
+  {
+    "dataSchema": {
+      "dataSource": "foodmart",
+      "parser": {
+        "parseSpec": {
+          "format": "json",
+          "timestampSpec": {
+            "column": "the_date",
+            "format": "iso"
+          },
+          "dimensionsSpec": {
+            "dimensions": [
+              "gender",
+              "country",
+              "state_province"
+            ],
+            "dimensionExclusions": [
+
+            ],
+            "spatialDimensions": [
+            ]
+          }
+        }
+      },
+      "metricsSpec": [
+        {
+          "name": "sales",
+          "type": "count"
+        },
+        {
+          "fieldName": "unit_sales",
+          "name": "unit_sales",
+          "type": "doubleSum"
+        },
+        {
+          "fieldName": "store_sales",
+          "name": "store_sales",
+          "type": "doubleSum"
+        }
+      ],
+      "granularitySpec": {
+        "type": "uniform",
+        "segmentGranularity": "DAY",
+        "queryGranularity": "NONE"
+      }
+    },
+    "ioConfig": {
+      "type": "realtime",
+      "firehose": {
+        "type": "local",
+        "filter": "*.json",
+        "baseDir": "foodmart/data"
+      },
+      "plumber": {
+        "type": "realtime",
+        "rejectionPolicy": {
+          "type": "test"
+         }
+      }
+    },
+    "tuningConfig": {
+        "type" : "realtime",
+        "maxRowsInMemory": 500000,
+        "intermediatePersistPeriod": "P10000d",
+        "windowPeriod": "P10000d",
+        "basePersistDirectory": "\/tmp\/realtime\/basePersist",
+        "rejectionPolicy": {
+            "type": "serverTime"
+        }
+    }
+  }
+]

--- a/src/test/resources/mysql-foodmart-model.json
+++ b/src/test/resources/mysql-foodmart-model.json
@@ -1,0 +1,17 @@
+{
+  version: '1.0',
+  defaultSchema: 'FOODMART',
+  schemas: [
+    {
+      name: 'FOODMART',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    }
+  ]
+}

--- a/src/test/resources/mysql-mysql-foodmart-model.json
+++ b/src/test/resources/mysql-mysql-foodmart-model.json
@@ -1,0 +1,28 @@
+{
+  version: '1.0',
+  //defaultSchema: 'FOODMART',
+  schemas: [
+    {
+      name: 'foodmart',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    },
+    {
+      name: 'db_example',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/foodmart2',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    }
+  ]
+}

--- a/src/test/resources/mysql-persons-model.json
+++ b/src/test/resources/mysql-persons-model.json
@@ -1,0 +1,17 @@
+{
+  version: '1.0',
+  defaultSchema: 'persons',
+  schemas: [
+    {
+      name: 'persons',
+      type: 'custom',
+      factory: 'org.apache.calcite.adapter.jdbc.JdbcSchema$Factory',
+      operand: {
+        jdbcDriver: 'com.mysql.jdbc.Driver',
+        jdbcUrl: 'jdbc:mysql://ec2-54-201-169-42.us-west-2.compute.amazonaws.com/db_example',
+        jdbcUser: 'root',
+        jdbcPassword: 'pass'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This change fixes data source IP and adds demo-able query to readme: 

select "t1".* from "mysql"."foodmart" as "t1" join "druid"."foodmart" as "t2" on "t1"."postal_code" = "t2"."postal_code" and "t2"."timestamp" >= '1900-01-01T00:00:00.000Z' and "t2"."timestamp" < '1997-01-01T12:00:00.000Z' and "t1"."postal_code" = 12422